### PR TITLE
gh-2: Fixes MIDI support in the Hardware Test.

### DIFF
--- a/examples/hardware_test.cpp
+++ b/examples/hardware_test.cpp
@@ -209,6 +209,7 @@ int main(void)
     cv2.Init(bluemchen.controls[bluemchen.CTRL_4], -5000.0f, 5000.0f, Parameter::LINEAR);
 
     bluemchen.StartAudio(AudioCallback);
+    bluemchen.midi.StartReceive();
 
     // Test the SD card
     sd_test_result = TestSdCard();


### PR DESCRIPTION
Here's a small fix so that the Hardware Test example properly receives and displays incoming MIDI note messages.